### PR TITLE
fix build error on Ubuntu 16.04

### DIFF
--- a/Evolve.pro
+++ b/Evolve.pro
@@ -34,8 +34,6 @@ FORMS    += widget.ui \
     progressdialog.ui \
     settingswidget.ui
 
-CONFIG += c++11
-
-QMAKE_CXXFLAGS_RELEASE += -O3 -flto -march=native -mmmx # Crashes on some computers
-QMAKE_CXXFLAGS_DEBUG += -Og -g -march=native -mmmx # Crashes on some computers
+QMAKE_CXXFLAGS_RELEASE += -std=c++11 -O3 -flto -march=native -mmmx # Crashes on some computers
+QMAKE_CXXFLAGS_DEBUG += -std=c++11 -Og -g -march=native -mmmx # Crashes on some computers
 #QMAKE_CXXFLAGS_DEBUG += -Og

--- a/mutation.cpp
+++ b/mutation.cpp
@@ -66,7 +66,7 @@ void Widget::reorderPoly(QVector<Poly>& newPolys, QImage &target)
             break;
     }
     int dest = qrand()%newPolys.size();
-    Poly poly = newPolys.takeAt(source);
+    Poly poly = newPolys.at(source);
     newPolys.insert(dest, poly);
     redraw(target, newPolys);
     optimizeShape(dest, newPolys);

--- a/widget.cpp
+++ b/widget.cpp
@@ -9,7 +9,8 @@
 #include <QPen>
 #include <QPainter>
 #include <QRgb>
-#include <QtConcurrent/QtConcurrent>
+#include <QtConcurrentRun>
+#include <QTimer>
 #include <ctime>
 
 //#define TIME_FITNESS


### PR DESCRIPTION
There was a bunch of build errors on Ubuntu 16.04. I've fixed them, but did not test if the fixes break anything on Windows.

Short summary:
- fix missing `QtConcurrent` header. It is not present on Ubuntu.
- fix `c++11` configuration not being read
- fix vector access. No `takeAt` method available. Replaced with generic `at` method. In case you don't need to check the boundaries, one can replace it with `[index]`. 